### PR TITLE
add new resources from 12/28/2015

### DIFF
--- a/lib/coffin.js
+++ b/lib/coffin.js
@@ -69,6 +69,7 @@
           DeliveryChannel: null
         },
         DirectoryService: {
+          MicrosoftAD: null,
           SimpleAD: null
         },
         CloudTrail: {
@@ -152,7 +153,9 @@
           Key: null
         },
         Logs: {
+          Destination: null,
           LogGroup: null,
+          LogStream: null,
           MetricFilter: null,
           SubscriptionFilter: null
         },
@@ -207,6 +210,13 @@
         },
         SSM: {
           Document: null
+        },
+        WAF: {
+          ByteMatchSet: null,
+          IPSet: null,
+          Rule: null,
+          SqlInjectionMatchSet: null,
+          WebACL: null
         },
         WorkSpaces: {
           Workspace: null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name":         "coffyn",
-  "version":      "0.3.9",
+  "version":      "0.3.10",
   "description":  "Coffee dsl for aws cloudformation",
   "keywords":     ["coffeescript", "coffee-script", "aws", "cloudformation"],
   "author":       "Joseph Yølk Chiocchi <joe@yolk.cc> (https://github.com/yyolk)",

--- a/src/coffin.coffee
+++ b/src/coffin.coffee
@@ -45,6 +45,7 @@ class CloudFormationTemplateContext
         ConfigurationRecorder: null
         DeliveryChannel: null
       DirectoryService:
+        MicrosoftAD: null
         SimpleAD: null
       CloudTrail:
         Trail: null
@@ -115,7 +116,9 @@ class CloudFormationTemplateContext
       KMS:
         Key: null
       Logs:
+        Destination: null
         LogGroup: null
+        LogStream: null
         MetricFilter: null
         SubscriptionFilter: null
       Lambda:
@@ -160,6 +163,12 @@ class CloudFormationTemplateContext
         QueuePolicy: null
       SSM:
         Document: null
+      WAF:
+        ByteMatchSet: null
+        IPSet: null
+        Rule: null
+        SqlInjectionMatchSet: null
+        WebACL: null
       WorkSpaces:
         Workspace: null
     @Param =


### PR DESCRIPTION
via http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html : 

> AWS CloudFormation added the following resources:
> - AWS::DirectoryService::MicrosoftAD
>   Use the Microsoft Active Directory resource to create a Microsoft Active Directory directory in AWS.
> - AWS::Logs::Destination and AWS::Logs::LogStream
>   Use the Amazon CloudWatch Logs resources to create a destination for real-time processing of log data or to create log streams, respectively.
> - AWS::WAF::ByteMatchSet, AWS::WAF::IPSet, AWS::WAF::Rule, AWS::WAF::SqlInjectionMatchSet, and AWS::WAF::WebACL
>   Use the AWS WAF resources to control and monitor web requests to your content.
